### PR TITLE
Makes the dealer more deadly.

### DIFF
--- a/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
+++ b/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
@@ -32,17 +32,17 @@ const ROUNDTYPE_DOUBLEORNOTHING = 2
 
 const itemScoreArray = [
 	[], [], [], # Skip none, shoot self, shoot other
-	# 0    1    2    3    4    5    6     7    8
-	[ 0.0, 1.5, 3.0, 4.0 , 4.5, 5.0 , 6.5 , 6.8, 7.0  ], # Magnify
-	[ 0.0, 0.5, 1.0, 1.2 , 1.2, 1.2 , 1.2 , 1.2, 1.2  ], # Cigarette
-	[ 0.0, 1.0, 2.0, 3.0 , 3.5, 4.0 , 4.25, 4.5, 4.75 ], # Beer
-	[ 0.0, 1.2, 2.0, 2.5 , 2.6, 2.7 , 2.8 , 2.9, 3.0  ], # Handcuff
-	[ 0.0, 1.5, 2.6, 3.1 , 3.5, 3.6 , 3.7 , 3.8, 3.9  ], # Handsaw
-	[ 0.0, 0.3, 0.6, 0.7 , 0.8, 0.9 , 0.95, 1.0, 1.05 ], # Expired Medicine
-	[ 0.0, 1.2, 2.4, 3.3 , 3.7, 4.1 , 4.5 , 4.9, 5.4  ], # Inverter
-	[ 0.0, 1.4, 2.8, 2.75, 2.7, 2.65, 2.6 , 2.5, 2.4  ], # Burner Phone
-	[ 0.0, 2.0, 4.0, 5.5 , 7.0, 8.0 , 9.0 , 9.5, 10   ], # Adrenaline
-	[ 0.0, 1.0, 2.0, 2.6 , 3.0, 3.0 , 3.0 , 3.0, 3.0, ], # FreeSlots
+	# 0    1    2    3     4     5     6     7    8
+	[ 0.0, 1.5, 3.0, 4.0 , 4.5 , 5.0 , 6.5 , 6.8, 7.0  ], # Magnify
+	[ 0.0, 0.5, 1.0, 1.2 , 1.2 , 1.2 , 1.2 , 1.2, 1.2  ], # Cigarette
+	[ 0.0, 1.0, 2.0, 3.0 , 3.5 , 4.0 , 4.25, 4.5, 4.75 ], # Beer
+	[ 0.0, 1.2, 2.0, 2.5 , 2.6 , 2.7 , 2.8 , 2.9, 3.0  ], # Handcuff
+	[ 0.0, 1.5, 2.6, 3.1 , 3.5 , 3.6 , 3.7 , 3.8, 3.9  ], # Handsaw
+	[ 0.0, 0.3, 0.6, 0.7 , 0.8 , 0.9 , 0.95, 1.0, 1.05 ], # Expired Medicine
+	[ 0.0, 1.2, 2.4, 3.3 , 3.7 , 4.1 , 4.5 , 4.9, 5.4  ], # Inverter
+	[ 0.0, 1.4, 2.8, 2.75, 2.7 , 2.65, 2.6 , 2.5, 2.4  ], # Burner Phone
+	[ 0.0, 2.0, 4.0, 5.5 , 7.0 , 8.0 , 9.0 , 9.5, 10.0 ], # Adrenaline
+	[ 0.0, 1.0, 2.0, 2.75, 3.25, 3.5 , 3.5 , 3.5, 3.5, ], # FreeSlots
 ]
 
 class Result:
@@ -214,12 +214,10 @@ class BruteforcePlayer:
 		var totalItems = self.count_items()
 		var freeSlots = 8 - totalItems
 
-		# Player 0 can consume cigarettes next turn, so saving them makes you less likely to draw more cigarettes
-		var cigaretteMultiplier = 1 if freeSlots < 4 else 2
 		var score: float = 0
 		score += itemScoreArray[OPTION_MAGNIFY][self.magnify]
 		score += itemScoreArray[OPTION_BEER][self.beer]
-		score += itemScoreArray[OPTION_CIGARETTES][self.cigarettes] * cigaretteMultiplier
+		score += itemScoreArray[OPTION_CIGARETTES][self.cigarettes]
 		score += itemScoreArray[OPTION_HANDSAW][self.handsaw]
 		score += itemScoreArray[OPTION_HANDCUFFS][self.handcuffs]
 		score += itemScoreArray[OPTION_MEDICINE][self.medicine]

--- a/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
+++ b/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
@@ -744,7 +744,9 @@ static func GetBestChoiceAndDamage_Internal(roundType: int, liveCount: int, blan
 		options[OPTION_SHOOT_SELF].mutAdd(resultIfSelfShootLive.mult(liveChance))
 
 	if blankChance > 0:
-		var resultIfSelfShootBlank := GetBestChoiceAndDamage_Internal(roundType, liveCount - invertedRemove, blankCount - originalRemove, liveCount_max, player, opponent, tempStates.SkipBullet())
+		var selfShootState := tempStates.SkipBullet()
+		selfShootState.usedHandsaw = false
+		var resultIfSelfShootBlank := GetBestChoiceAndDamage_Internal(roundType, liveCount - invertedRemove, blankCount - originalRemove, liveCount_max, player, opponent, selfShootState)
 
 		var resultIfShootBlank := Result.new(OPTION_SHOOT_OTHER, [0.0, 0.0], [0.0, 0.0], [0.0, 0.0])
 		if tempStates.handcuffState <= HANDCUFF_FREENEXT:

--- a/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
+++ b/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
@@ -417,6 +417,7 @@ class TempStates:
 # liveCount and blankCount both contain the count of bullets without considering the effect of active inverters.
 # tempStates.magnifyingGlassResult does consider the effect of active inverters.
 static var printOptions = false
+static var enableDebugTrace = false
 static var cachedGame: BruteforceGame = null
 static var cache = {}
 static func GetBestChoiceAndDamage(roundType: int, liveCount: int, blankCount: int, player: BruteforcePlayer, opponent: BruteforcePlayer, tempStates: TempStates):
@@ -775,9 +776,10 @@ static func GetBestChoiceAndDamage_Internal(roundType: int, liveCount: int, blan
 		options[OPTION_SHOOT_SELF].mutAdd(resultIfSelfShootBlank.mult(blankChance))
 
 
-	if printOptions and isTopLayer:
+	if (printOptions and isTopLayer) or enableDebugTrace:
 		print(options, " (", ahash, ")")
-		# print(player, " ", opponent, " ", tempStates)
+	if enableDebugTrace:
+		print("%s Live, %s Blank\n%s\n%s\n%s" % [liveCount, blankCount, player, opponent, tempStates])
 
 	var current: Result = null
 	var results: Array[Result] = []

--- a/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
+++ b/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
@@ -888,7 +888,7 @@ static func GetBestChoiceAndDamage_Internal(roundType: int, liveCount: int, blan
 			results = [current]
 			continue
 
-		var comparison = CompareCurrent(player.player_index == 0, false, current, option)
+		var comparison = CompareCurrent(player.player_index == 0, current, option)
 		if comparison == 0:
 			results.append(option)
 			continue
@@ -942,7 +942,7 @@ static var dealerKillCutoff: float = 0.8
 static var dealerDeathCutoff: float = 0.8
 
 # -1 means current is better than other
-static func CompareCurrent(isPlayer0: bool, donLogic: bool, current: Result, other: Result):
+static func CompareCurrent(isPlayer0: bool, current: Result, other: Result):
 	if isPlayer0:
 		# Lower is better
 		comparison = Compare(
@@ -971,38 +971,19 @@ static func CompareCurrent(isPlayer0: bool, donLogic: bool, current: Result, oth
 	var myIndex = 0 if isPlayer0 else 1
 	var otherIndex = 1 if isPlayer0 else 0
 
-	if donLogic and not isPlayer0:
-		if not isPlayer0:
-			if current.deathChance[0] >= dealerKillCutoff:
-				if other.deathChance[0] < dealerKillCutoff:
-					return -1
-			elif other.deathChance[0] >= dealerKillCutoff:
-				return 1
-		else:
-			# Higher is better
-			var killComparison = Compare(other.deathChance[otherIndex], current.deathChance[otherIndex])
-			if killComparison != 0:
-				return killComparison
+	# Higher is better
+	var killComparison = Compare(other.deathChance[otherIndex], current.deathChance[otherIndex])
+	if killComparison != 0:
+		return killComparison
+
+	if Compare(other.deathChance[otherIndex], 1.0) >= 0:
+		var itemDiff = current.itemScore[myIndex] - current.itemScore[otherIndex]
+		var otherItemDiff = other.itemScore[myIndex] - other.itemScore[otherIndex]
 
 		# Higher is better
-		var itemComparison = Compare(other.itemScore[otherIndex], current.itemScore[otherIndex])
-		if itemComparison != 0:
-			return itemComparison
-
-	else:
-		# Higher is better
-		var killComparison = Compare(other.deathChance[otherIndex], current.deathChance[otherIndex])
-		if killComparison != 0:
-			return killComparison
-
-		if Compare(other.deathChance[otherIndex], 1.0) >= 0:
-			var itemDiff = current.itemScore[myIndex] - current.itemScore[otherIndex]
-			var otherItemDiff = other.itemScore[myIndex] - other.itemScore[otherIndex]
-
-			# Higher is better
-			var comparison = Compare(otherItemDiff, itemDiff)
-			if comparison != 0:
-				return comparison
+		var comparison = Compare(otherItemDiff, itemDiff)
+		if comparison != 0:
+			return comparison
 
 	var healthDiff = current.healthScore[myIndex] - current.healthScore[otherIndex]
 	var otherHealthDiff = other.healthScore[myIndex] - other.healthScore[otherIndex]

--- a/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
+++ b/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
@@ -637,8 +637,7 @@ static func GetBestChoiceAndDamage_Internal(roundType: int, liveCount: int, blan
 			var blankBeerResult = GetBestChoiceAndDamage_Internal(roundType, liveCount - invertedRemove, blankCount - originalRemove, liveCount_max, beerPlayer, beerOpponent, tempStates.SkipBullet())
 			options[OPTION_BEER].mutAdd(blankBeerResult.mult(blankChance))
 
-	# Dealer isn't allowed to eat medicine on 1 health left... for some reason
-	if itemFrom.medicine > 0 and (player.player_index == 0 or player.health > 1):
+	if itemFrom.medicine > 0:
 		var medicinePlayer := player.use("medicine", 0 if tempStates.adrenaline else 1)
 		var medicineOpponent := opponent.use("medicine", 1 if tempStates.adrenaline else 0)
 

--- a/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
+++ b/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
@@ -735,7 +735,7 @@ static func GetBestChoiceAndDamage_Internal(roundType: int, liveCount: int, blan
 		options[OPTION_BURNER] = Result.new(OPTION_BURNER, [0.0, 0.0], [0.0, 0.0], [0.0, 0.0])
 
 		if bMissChance > 0:
-			var missResult = GetBestChoiceAndDamage_Internal(roundType, liveCount, blankCount, liveCount_max, a, b, tempStates)
+			var missResult = GetBestChoiceAndDamage_Internal(roundType, liveCount, blankCount, liveCount_max, a, b, tempStates.Future(0, 0))
 			options[OPTION_BURNER].mutAdd(missResult.mult(bMissChance))
 		if bLiveChance > 0:
 			var liveResult = GetBestChoiceAndDamage_Internal(roundType, liveCount, blankCount, liveCount_max, a, b, tempStates.Future(1, 0))

--- a/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
+++ b/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
@@ -459,7 +459,7 @@ static func sum_array(array)->float:
 
 static func GetBestChoiceAndDamage_Internal(roundType: int, liveCount: int, blankCount: int, liveCount_max: int, player: BruteforcePlayer, opponent: BruteforcePlayer, tempStates: TempStates, isTopLayer:=false)->Result:
 	if player.health <= 0 or opponent.health <= 0:
-		var deadPlayerIs0 = (player.player_index if player.health == 0 else opponent.player_index) == 0
+		var deadPlayerIs0 = (player.player_index if player.health <= 0 else opponent.player_index) == 0
 
 		var deathScore := [1.0, 0.0] if deadPlayerIs0 else [0.0, 1.0]
 

--- a/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
+++ b/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
@@ -386,10 +386,12 @@ class TempStates:
 
 
 	func do_hash(num: int, liveCount_max: int)->int:
-		num = ((num * 3 + self.handcuffState) * 3 + self.magnifyingGlassResult) * 4
+		num = ((num * 3 + self.handcuffState) * 3 + self.magnifyingGlassResult) * 8
 		if self.usedHandsaw:
-			num += 2
+			num += 4
 		if self.inverted:
+			num += 2
+		if self.adrenaline:
 			num += 1
 		num *= (liveCount_max+1)
 		num += self.futureLive

--- a/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
+++ b/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
@@ -58,7 +58,7 @@ class Result:
 		self.healthScore.assign(healthScore)
 		self.itemScore.assign(itemScore)
 
-	func mult(multiplier):
+	func mult(multiplier: float):
 		return Result.new(
 			self.option,
 			[multiplier*self.deathChance[0], multiplier*self.deathChance[1]],

--- a/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
+++ b/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
@@ -216,7 +216,7 @@ class BruteforcePlayer:
 
 		# Player 0 can consume cigarettes next turn, so saving them makes you less likely to draw more cigarettes
 		var cigaretteMultiplier = 1 if freeSlots < 4 else 2
-		var score: int = 0
+		var score: float = 0
 		score += itemScoreArray[OPTION_MAGNIFY][self.magnify]
 		score += itemScoreArray[OPTION_BEER][self.beer]
 		score += itemScoreArray[OPTION_CIGARETTES][self.cigarettes] * cigaretteMultiplier

--- a/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
+++ b/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
@@ -210,7 +210,7 @@ class BruteforcePlayer:
 		copy.adrenaline = other.adrenaline
 		return copy
 
-	func sum_items()->int:
+	func sum_items()->float:
 		var totalItems = self.count_items()
 		var freeSlots = 8 - totalItems
 

--- a/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
+++ b/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
@@ -499,14 +499,21 @@ static func GetBestChoiceAndDamage_Internal(roundType: int, liveCount: int, blan
 		health[player.player_index] = player.health
 		health[opponent.player_index] = opponent.health
 
-		var itemscore: Array[float] = [0.0, 0.0]
-		itemscore[player.player_index] = player.sum_items()
-		itemscore[opponent.player_index] = opponent.sum_items()
+		var itemScore: Array[float] = [0.0, 0.0]
+		itemScore[player.player_index] = player.sum_items()
+		itemScore[opponent.player_index] = opponent.sum_items()
 
+		# The player can always smoke at the beginning of the next round if they don't die this round.
+		# (The same isn't true for the dealer, who could be killed before he can take a turn.)
+		# Count the health and item scores for the player using their cigarettes at the beginning of the next round, but
+		# don't give them the extra FreeSlots value. (The cigarettes are still occupying a slot during item distribution.)
 		var startingPlayer = player if player.player_index == 0 else opponent
-		var otherPlayer = player if player.player_index == 1 else opponent
+		var smokeAmount: int = min(startingPlayer.cigarettes, startingPlayer.max_health - startingPlayer.health)
+		health[0] += smokeAmount
+		itemScore[0] -= itemScoreArray[OPTION_CIGARETTES][startingPlayer.cigarettes]
+		itemScore[0] += itemScoreArray[OPTION_CIGARETTES][startingPlayer.cigarettes - smokeAmount]
 
-		var result = Result.new(OPTION_NONE, deathChance, health, itemscore)
+		var result = Result.new(OPTION_NONE, deathChance, health, itemScore)
 		cache[ahash] = result
 		return result.clone()
 

--- a/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
+++ b/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
@@ -351,6 +351,10 @@ class TempStates:
 	func Invert()->TempStates:
 		var other: TempStates = self.clone()
 		other.inverted = not other.inverted
+		if self.magnifyingGlassResult == MAGNIFYING_LIVE:
+			other.magnifyingGlassResult = MAGNIFYING_BLANK
+		elif self.magnifyingGlassResult == MAGNIFYING_BLANK:
+			other.magnifyingGlassResult = MAGNIFYING_LIVE
 		other.adrenaline = false
 		return other
 
@@ -485,9 +489,6 @@ static func GetBestChoiceAndDamage_Internal(roundType: int, liveCount: int, blan
 	if cache.has(ahash) and not isTopLayer:
 		return cache[ahash].clone()
 
-	# Double or nothing round has special logic
-	var donLogic = roundType == ROUNDTYPE_DOUBLEORNOTHING and player.player_index == 1
-
 	if liveCount == 0 and blankCount == 0:
 		var deathChance: Array[float] = [0.0, 0.0]
 
@@ -524,11 +525,12 @@ static func GetBestChoiceAndDamage_Internal(roundType: int, liveCount: int, blan
 	var originalRemove := 1
 	var invertedRemove := 0
 	if tempStates.inverted:
-		var temp = liveChance
-		liveChance = blankChance
-		blankChance = temp
 		originalRemove = 0
 		invertedRemove = 1
+		if tempStates.magnifyingGlassResult == MAGNIFYING_NONE:
+			var temp = liveChance
+			liveChance = blankChance
+			blankChance = temp
 
 	# Some hard-coded kills to speed up:
 	if player.player_index == 1:

--- a/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
+++ b/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
@@ -731,10 +731,10 @@ static func GetBestChoiceAndDamage_Internal(roundType: int, liveCount: int, blan
 			var missResult = GetBestChoiceAndDamage_Internal(roundType, liveCount, blankCount, liveCount_max, a, b, tempStates)
 			options[OPTION_BURNER].mutAdd(missResult.mult(bMissChance))
 		if bLiveChance > 0:
-			var liveResult = GetBestChoiceAndDamage_Internal(roundType, liveCount, blankCount, liveCount_max, a, b, tempStates.Future(0, 1))
+			var liveResult = GetBestChoiceAndDamage_Internal(roundType, liveCount, blankCount, liveCount_max, a, b, tempStates.Future(1, 0))
 			options[OPTION_BURNER].mutAdd(liveResult.mult(bLiveChance))
 		if bBlankChance > 0:
-			var blankResult = GetBestChoiceAndDamage_Internal(roundType, liveCount, blankCount, liveCount_max, a, b, tempStates.Future(1, 0))
+			var blankResult = GetBestChoiceAndDamage_Internal(roundType, liveCount, blankCount, liveCount_max, a, b, tempStates.Future(0, 1))
 			options[OPTION_BURNER].mutAdd(blankResult.mult(bBlankChance))
 
 	var damageToDeal := 2 if tempStates.usedHandsaw else 1

--- a/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
+++ b/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
@@ -414,7 +414,7 @@ class TempStates:
 
 # liveCount and blankCount both contain the count of bullets without considering the effect of active inverters.
 # tempStates.magnifyingGlassResult does consider the effect of active inverters.
-static var printOptions = false
+static var printOptions = true
 static var enableDebugTrace = false
 static var cachedGame: BruteforceGame = null
 static var cache = {}

--- a/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
+++ b/mods-unpacked/ITR-SmarterDealer/bruteforce.gd
@@ -670,7 +670,7 @@ static func GetBestChoiceAndDamage_Internal(roundType: int, liveCount: int, blan
 		var result = GetBestChoiceAndDamage_Internal(roundType, liveCount, blankCount, liveCount_max, a, b, tempStates.Saw())
 		options[OPTION_HANDSAW] = result
 
-	if not tempStates.adrenaline and player.adrenaline > 0 and (opponent.magnify > 0 or opponent.burner > 0 or opponent.beer > 0 or (opponent.handcuffs > 0 and tempStates.handcuffState == HANDCUFF_NONE) or (opponent.handsaw > 0 and not tempStates.usedHandsaw) or opponent.cigarettes > 0 or (opponent.medicine > 0 and (player.player_index == 0 or player.health > 1)) or opponent.inverter > 0):
+	if not tempStates.adrenaline and player.adrenaline > 0:
 		var result := GetBestChoiceAndDamage_Internal(roundType, liveCount, blankCount, liveCount_max, player.use("adrenaline"), opponent, tempStates.Adrenaline())
 		options[OPTION_ADRENALINE] = result
 
@@ -765,14 +765,6 @@ static func GetBestChoiceAndDamage_Internal(roundType: int, liveCount: int, blan
 	var results: Array[Result] = []
 
 	for key in options:
-		if (tempStates.usedHandsaw or tempStates.adrenaline) and key == OPTION_SHOOT_SELF:
-			# Disallow this for now
-			continue
-
-		if tempStates.adrenaline and key == OPTION_SHOOT_OTHER:
-			# Easier than not traveling down the path
-			continue
-
 		var option = options[key].clone()
 		option.option = key
 
@@ -792,35 +784,11 @@ static func GetBestChoiceAndDamage_Internal(roundType: int, liveCount: int, blan
 		current = option
 		results = [current]
 
-	if results.size() <= 0:
-		print("Oops! Bad pathing! Probably adrenaline's fault again!:\n", options)
-		results = [Result.new(
-			OPTION_NONE,
-			[-100, 100],
-			[100, -100],
-			[100, -100]
-		)]
+	if results.size() > 1:
+		results.shuffle()
 
-	if results.size() <= 1:
-		cache[ahash] = results[0]
-		return results[0].clone()
-
-	results.shuffle()
 	cache[ahash] = results[0]
 	return results[0].clone()
-
-
-static func RandomizeDealer():
-	# TODO(rballard): See what these were supposed to be doing.
-	var dealerKillCutoff := randf()
-	var dealerDeathCutoff := randf()
-
-	ModLoaderLog.info(
-		"Randomized dealer!\nkillCutoff %s\ndeathCutoff %s" % [
-			dealerKillCutoff, dealerDeathCutoff
-		],
-		"ITR-SmarterDealer"
-	)
 
 # -1 means current is better than other
 static func CompareCurrent(isPlayer0: bool, current: Result, other: Result):

--- a/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
+++ b/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
@@ -248,6 +248,12 @@ func CommentOnChance(playerDeathChance: float, dealerDeathChance: float):
 	shellLoader.dialogue.HideText()
 
 func DealerChoice()->void:
+	# Check if the dealer is dead, to cover the case where the dealer takes expired medicine on 1 health. (Which then leads to calling DealerChoice again.)
+	if roundManager.health_opponent <= 0:
+		roundManager.OutOfHealth("dealer")
+		healthCounter.UpdateDisplayRoutine(false, false, true)
+		return
+
 	if (roundManager.requestedWireCut):
 		await(roundManager.defibCutter.CutWire(roundManager.wireToCut))
 	if adrenaline:

--- a/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
+++ b/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
@@ -386,11 +386,13 @@ func DealerChoice()->void:
 		await get_tree().create_timer(1.4 + .5 - 1, false).timeout
 	await get_tree().create_timer(1, false).timeout
 	print("Dealer shoots "+dealerTarget)
+	var firedLive := shellSpawner.sequenceArray[0] == "live"
 	Shoot(dealerTarget)
-	commentedThisTurn = false
 
+	if dealerTarget == "player || firedLive:
+		commentedThisTurn = false
 	# Make the barrel regrow after the dealer shoots himself, to be consistent with the player. (This case just never comes up with the vanilla AI.)
-	if (roundManager.barrelSawedOff && dealerTarget == "self"):
+	if (roundManager.barrelSawedOff && dealerTarget == "self" && not firedLive):
 		if (dealerHoldingShotgun):
 			animator_shotgun.play("enemy put down shotgun")
 			shellLoader.DealerHandsDropShotgun()

--- a/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
+++ b/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
@@ -387,6 +387,7 @@ func DealerChoice()->void:
 	await get_tree().create_timer(1, false).timeout
 	print("Dealer shoots "+dealerTarget)
 	Shoot(dealerTarget)
+	commentedThisTurn = false
 
 	# Make the barrel regrow after the dealer shoots himself, to be consistent with the player. (This case just never comes up with the vanilla AI.)
 	if (roundManager.barrelSawedOff && dealerTarget == "self"):
@@ -402,13 +403,3 @@ func DealerChoice()->void:
 	inverted_shell = false
 
 	return
-
-func EndTurnMain():
-	commentedThisTurn = false
-	await get_tree().create_timer(.5, false).timeout
-	camera.BeginLerp("home")
-	if (dealerHoldingShotgun):
-		animator_shotgun.play("enemy put down shotgun")
-		shellLoader.DealerHandsDropShotgun()
-	dealerHoldingShotgun = false
-	roundManager.EndTurn(true)

--- a/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
+++ b/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
@@ -387,10 +387,6 @@ func DealerChoice()->void:
 	await get_tree().create_timer(1, false).timeout
 	print("Dealer shoots "+dealerTarget)
 	Shoot(dealerTarget)
-	dealerTarget = ""
-	knownShell = ""
-	dealerKnowsShell = false
-	inverted_shell = false
 
 	# Make the barrel regrow after the dealer shoots himself, to be consistent with the player. (This case just never comes up with the vanilla AI.)
 	if (roundManager.barrelSawedOff && dealerTarget == "self"):
@@ -399,6 +395,11 @@ func DealerChoice()->void:
 			shellLoader.DealerHandsDropShotgun()
 		await get_tree().create_timer(.6, false).timeout
 		await(roundManager.segmentManager.GrowBarrel())
+
+	dealerTarget = ""
+	knownShell = ""
+	dealerKnowsShell = false
+	inverted_shell = false
 
 	return
 

--- a/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
+++ b/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
@@ -93,7 +93,7 @@ func AlternativeChoice(isPlayer: bool = false, overrideShell = ""):
 				blankUnknown += 1
 
 	var roundType = Bruteforce.ROUNDTYPE_NORMAL
-	if roundManager.defibCutterReady && !roundManager.endless:
+	if roundManager.defibCutterReady and !roundManager.endless:
 		roundType = Bruteforce.ROUNDTYPE_WIRECUT
 	elif roundManager.playerData.currentBatchIndex == 2:
 		roundType = Bruteforce.ROUNDTYPE_DOUBLEORNOTHING
@@ -389,10 +389,10 @@ func DealerChoice()->void:
 	var firedLive := shellSpawner.sequenceArray[0] == "live"
 	Shoot(dealerTarget)
 
-	if dealerTarget == "player || firedLive:
+	if dealerTarget == "player" or firedLive:
 		commentedThisTurn = false
 	# Make the barrel regrow after the dealer shoots himself, to be consistent with the player. (This case just never comes up with the vanilla AI.)
-	if (roundManager.barrelSawedOff && dealerTarget == "self" && not firedLive):
+	if roundManager.barrelSawedOff and dealerTarget == "self" and not firedLive:
 		if (dealerHoldingShotgun):
 			animator_shotgun.play("enemy put down shotgun")
 			shellLoader.DealerHandsDropShotgun()

--- a/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
+++ b/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
@@ -109,7 +109,7 @@ func AlternativeChoice(isPlayer: bool = false, overrideShell = ""):
 	var totalShells = shellSpawner.sequenceArray.size()
 
 	# Some probably dumb plays to prevent the AI from spending ages thinking
-	if itemsInPlay >= 12 and totalShells > 4:
+	if itemsInPlay + totalShells >= 16:
 		var check = player if isPlayer else dealer
 
 		if check.burner > 0:

--- a/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
+++ b/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
@@ -391,4 +391,13 @@ func DealerChoice()->void:
 	knownShell = ""
 	dealerKnowsShell = false
 	inverted_shell = false
+
+	# Make the barrel regrow after the dealer shoots himself, to be consistent with the player. (This case just never comes up with the vanilla AI.)
+	if (roundManager.barrelSawedOff && dealerTarget == "self"):
+		if (dealerHoldingShotgun):
+			animator_shotgun.play("enemy put down shotgun")
+			shellLoader.DealerHandsDropShotgun()
+		await get_tree().create_timer(.6, false).timeout
+		await(roundManager.segmentManager.GrowBarrel())
+
 	return

--- a/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
+++ b/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
@@ -70,7 +70,6 @@ func createPlayer(player_index, itemArray):
 	)
 
 
-var lastCommentedRound = -1
 var inverted_shell = false
 var adrenaline = false
 func AlternativeChoice(isPlayer: bool = false, overrideShell = ""):
@@ -172,6 +171,7 @@ func AlternativeChoice(isPlayer: bool = false, overrideShell = ""):
 	# Return the result, you might want to handle the result accordingly
 	return result.option
 
+var commentedThisTurn := false
 func CommentOnChance(playerDeathChance: float, dealerDeathChance: float):
 	var texts: Array
 
@@ -237,11 +237,11 @@ func CommentOnChance(playerDeathChance: float, dealerDeathChance: float):
 
 	texts.shuffle()
 	print(texts[0])
-	if roundManager.currentRound == lastCommentedRound:
+	if commentedThisTurn:
 		print("Comment skipped")
 		return
 
-	lastCommentedRound = roundManager.currentRound
+	commentedThisTurn = true
 
 	shellLoader.dialogue.ShowText_Forever(texts[0])
 	await get_tree().create_timer(2.3, false).timeout
@@ -401,3 +401,13 @@ func DealerChoice()->void:
 		await(roundManager.segmentManager.GrowBarrel())
 
 	return
+
+func EndTurnMain():
+	commentedThisTurn = false
+	await get_tree().create_timer(.5, false).timeout
+	camera.BeginLerp("home")
+	if (dealerHoldingShotgun):
+		animator_shotgun.play("enemy put down shotgun")
+		shellLoader.DealerHandsDropShotgun()
+	dealerHoldingShotgun = false
+	roundManager.EndTurn(true)

--- a/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
+++ b/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
@@ -70,7 +70,7 @@ func createPlayer(player_index, itemArray):
 	)
 
 
-var prevWonRounds = -1
+var lastCommentedRound = -1
 var inverted_shell = false
 var adrenaline = false
 func AlternativeChoice(isPlayer: bool = false, overrideShell = ""):
@@ -167,19 +167,13 @@ func AlternativeChoice(isPlayer: bool = false, overrideShell = ""):
 	)
 	ModLoaderLog.info("%s" % result, "ITR-SmarterDealer")
 
-	# Disabled until I figure out how A: roundManager.wonRounds doesn't exist, and B: How the code works in spite of this
-	# if prevWonRounds != roundManager.wonRounds:
-	# 	prevWonRounds = roundManager.wonRounds
-	# 	CommentOnChance(result.deathChance[0], result.deathChance[1])
+	CommentOnChance(result.deathChance[0], result.deathChance[1])
 
 	# Return the result, you might want to handle the result accordingly
 	return result.option
 
-var commentDelay = 3
 func CommentOnChance(playerDeathChance: float, dealerDeathChance: float):
 	var texts: Array
-
-	commentDelay -= 1
 
 	if playerDeathChance >= 0.65:
 		texts = [
@@ -243,11 +237,11 @@ func CommentOnChance(playerDeathChance: float, dealerDeathChance: float):
 
 	texts.shuffle()
 	print(texts[0])
-	if commentDelay > 0:
+	if roundManager.currentRound == lastCommentedRound:
 		print("Comment skipped")
 		return
 
-	commentDelay = 3
+	lastCommentedRound = roundManager.currentRound
 
 	shellLoader.dialogue.ShowText_Forever(texts[0])
 	await get_tree().create_timer(2.3, false).timeout

--- a/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
+++ b/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
@@ -70,17 +70,12 @@ func createPlayer(player_index, itemArray):
 	)
 
 
-var prevBatchIndex = -1
 var prevWonRounds = -1
 var inverted_shell = false
 var adrenaline = false
 func AlternativeChoice(isPlayer: bool = false, overrideShell = ""):
 	if (shellSpawner.sequenceArray.size() == 0):
 		return Bruteforce.OPTION_NONE
-
-	if roundManager.playerData.currentBatchIndex != prevBatchIndex:
-		Bruteforce.RandomizeDealer()
-		prevBatchIndex = roundManager.playerData.currentBatchIndex
 
 	var liveCount = 0
 	var blankCount = 0

--- a/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
+++ b/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
@@ -131,7 +131,7 @@ func AlternativeChoice(isPlayer: bool = false, overrideShell = ""):
 			shell = Bruteforce.MAGNIFYING_BLANK
 	else:
 		if dealerKnowsShell or sequenceArray_knownShell[0] or liveUnknown == 0 or blankUnknown == 0:
-			shell = Bruteforce.MAGNIFYING_LIVE if (shellSpawner.sequenceArray[0] == "live") != inverted_shell else Bruteforce.MAGNIFYING_BLANK
+			shell = Bruteforce.MAGNIFYING_LIVE if shellSpawner.sequenceArray[0] == "live" else Bruteforce.MAGNIFYING_BLANK
 
 	var playerHandcuffState = Bruteforce.HANDCUFF_NONE
 	if isPlayer:

--- a/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
+++ b/mods-unpacked/ITR-SmarterDealer/extensions/DealerIntelligence.gd
@@ -171,11 +171,13 @@ func AlternativeChoice(isPlayer: bool = false, overrideShell = ""):
 	# Return the result, you might want to handle the result accordingly
 	return result.option
 
-var commentedThisTurn := false
+var lastCommentType = ""
 func CommentOnChance(playerDeathChance: float, dealerDeathChance: float):
+	var commentType: String
 	var texts: Array
 
 	if playerDeathChance >= 0.65:
+		commentType = "player_danger"
 		texts = [
 			"say hello to god",
 			"greet god from me",
@@ -196,6 +198,7 @@ func CommentOnChance(playerDeathChance: float, dealerDeathChance: float):
 			"the end draws near",
 		]
 	elif dealerDeathChance >= 0.65:
+		commentType = "dealer_danger"
 		texts = [
 			"this isn't looking\nvery poggers",
 			"this is the end for me",
@@ -217,6 +220,7 @@ func CommentOnChance(playerDeathChance: float, dealerDeathChance: float):
 			"defiance in the face of doom",
 		]
 	elif playerDeathChance >= 0.4 and dealerDeathChance >= 0.4:
+		commentType = "fifty_fifty"
 		texts = [
 			"now we both dance on the\nedge of life and death",
 			"it's showdown time",
@@ -237,11 +241,11 @@ func CommentOnChance(playerDeathChance: float, dealerDeathChance: float):
 
 	texts.shuffle()
 	print(texts[0])
-	if commentedThisTurn:
+	if commentType == lastCommentType:
 		print("Comment skipped")
 		return
 
-	commentedThisTurn = true
+	lastCommentType = commentType
 
 	shellLoader.dialogue.ShowText_Forever(texts[0])
 	await get_tree().create_timer(2.3, false).timeout
@@ -384,8 +388,9 @@ func DealerChoice()->void:
 		DealerChoice()
 		return
 
-	if shellSpawner.sequenceArray[0] == "live" or dealerTarget == "player":
-		commentedThisTurn = false
+	# When the dealer shoots to end his turn, reset his last comment type so he can make any comment next turn.
+	if (shellSpawner.sequenceArray[0] == "live" or dealerTarget == "player") and not (roundManager.playerCuffed and not roundManager.playerAboutToBreakFree):
+		lastCommentType = ""
 
 	# shoot
 	if (roundManager.waitingForDealerReturn):


### PR DESCRIPTION
### At a high level, this change has two parts:
- Rework the way Results are calculated and compared, to make the base case evaluation more generally applicable / able to handle weird cases.
- Remove all of the restrictions preventing the dealer from taking weird-looking lines, because sometimes those lines are correct and the Results comparison code can properly evaluate those lines now.

There are also some bugfixes sprinkled in, some of which are for new cases that are only explored with the new search and some of which are for pre-existing bugs. The most notable is a fix for the interaction of inverters and magnifying glasses, which should fix issues https://github.com/ITR13/BuckshotRouletteMods/issues/9 and https://github.com/ITR13/BuckshotRouletteMods/issues/10.

### Explanation of the new Result logic
The dealer's priorities are, in order:
- Maximize the probability of killing the player this round.
- Maximize the probability of surviving to the next round.
- Maximize the dealer's expected health advantage.
- Maximize the dealer's expected item advantage.

The assumed priorities for the player are, in order:
- Maximize the probability of surviving to the next round.
- Maximize the probability of killing the dealer this round.
- Maximize the dealer's expected health advantage.
- Maximize the dealer's expected item advantage.

These priorities come from the heuristic that if the player makes it to the next round they're probably going to win, because going first with a fresh set of items is a big advantage. Notably, health advantage and item advantage only matter if nobody dies, (or if the dealer dies in a double-or-nothing round) so those are zeroed out in the cases where someone dies, to make the comparison logic correct.

### Notable new behaviors exhibited by the dealer
- The dealer can use medicine intelligently now. Some examples:
  - He takes medicine at 2 health in 4 max health rounds as long as it doesn't put him in death range.
  - He takes medicine at 1 health in situations where he's more than 50% likely to die otherwise.
  - He takes medicine when he's only missing 1 health to free up space for new items.
  - I've noticed that, as a high-variance item, medicine is actually pretty useful for the dealer, who's generally expected to lose and only needs to kill you once.
- The dealer will use adrenaline to steal your cigarettes, even when he's at full health, if taking the healing away from you makes him more likely to kill you.
- The dealer can use handsaws on known blank shells to prevent you stealing them with adrenaline. (And he can even shoot himself with a sawed-off shotgun, although the cases where he wants to do that are rare.)
- The dealer is better at conserving items when planning lines where items are only used conditionally. (Because of the Results zeroing out the item advantage in cases where someone dies.)